### PR TITLE
Update to use clfoundation sbcl image.

### DIFF
--- a/build/build.lisp
+++ b/build/build.lisp
@@ -1,8 +1,10 @@
-(load "quicklisp/setup")
+(load "./quicklisp/setup")
 (ql:quickload "analyzer")
 
-(sb-ext:save-lisp-and-die "analyzer"
-                          :toplevel #'(lambda ()
-                                        (apply #'analyzer/main:main
-                                               (uiop:command-line-arguments)))
-                          :executable t)
+(let ((bin-dir (make-pathname :directory '(:relative "bin"))))
+  (ensure-directories-exist bin-dir)
+  (sb-ext:save-lisp-and-die (merge-pathnames "analyzer" bin-dir)
+                            :toplevel #'(lambda ()
+                                          (apply #'analyzer/main:main
+                                                 (uiop:command-line-arguments)))
+                            :executable t))

--- a/build/install-quicklisp.lisp
+++ b/build/install-quicklisp.lisp
@@ -1,2 +1,2 @@
-(load "./src/quicklisp.lisp")
-(quicklisp-quickstart:install)
+(load "./build/quicklisp.lisp")
+(quicklisp-quickstart:install )


### PR DESCRIPTION
This change also includes a switch from ADD to RUN curl to get
quicklisp. ADD was giving a 'invalid not-modifed Etag' error which
kept the image from building.

Fixes #17.